### PR TITLE
fix: use keyup for escape key handler

### DIFF
--- a/src/dialog-renderer.js
+++ b/src/dialog-renderer.js
@@ -32,7 +32,7 @@ export class DialogRenderer {
   constructor(){
     this.dialogControllers = [];
 
-    document.addEventListener('keypress', e => {
+    document.addEventListener('keyup', e => {
       if (e.keyCode === 27){
         var top = this.dialogControllers[this.dialogControllers.length-1];
         if(top && top.settings.lock !== true){


### PR DESCRIPTION
Keyup is a more browser-compatible event for handling the escape key. Keydown is also viable, if you prefer to handle it that way.

The keypress event is not firing in Chrome (OSX v43).
